### PR TITLE
(maint)fix require for facter 4 on non windows platforms

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -14,7 +14,7 @@ CONFIG_FILE   = ARGV[0] || ''
 IS_GEM        = ARGV[1] || 'false'
 
 def load_files(*dirs)
-  dirs.each { |dir| Dir[ROOT_DIR.join(dir)].each { |file| require file } }
+  dirs.each { |dir| Dir[ROOT_DIR.join(dir)].sort.each { |file| require file } }
 end
 
 load_files(

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module FacterStatistax
-  VERSION = '0.0.9'
+  VERSION = '0.0.10'
 end

--- a/scripts/benchmark_script.rb
+++ b/scripts/benchmark_script.rb
@@ -3,6 +3,13 @@
 require 'benchmark'
 require 'open3'
 
+def facter_path(gems_path)
+  ruby_version = Dir.entries(gems_path).select { |file| file =~ /[0-9]+.[0-9]+.[0-9]+/ }
+  facter_ng_path = File.join(gems_path, ruby_version, 'gems')
+  facter_ng_version = Dir.entries(facter_ng_path).select { |file| file =~ /facter-4/ }
+  File.join(facter_ng_path, facter_ng_version, 'lib', 'facter.rb')
+end
+
 if ARGV[0].to_s == 'false'
   if Gem.win_platform?
     facter_dir = 'C:/Program Files/Puppet Labs/Puppet/puppet/bin'
@@ -12,14 +19,9 @@ if ARGV[0].to_s == 'false'
     require '/opt/puppetlabs/puppet/lib/libfacter.so'
   end
 elsif Gem.win_platform?
-  gems_path = 'C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/gems'
-  ruby_version = Dir.entries(gems_path).select { |file| file =~ /[0-9]+.[0-9]+.[0-9]+/ }
-  facter_ng_path =  File.join(gems_path, ruby_version, 'gems')
-  facter_ng_version = Dir.entries(facter_ng_path).select { |file| file =~ /facter-4/ }
-  facter_ng_path = File.join(facter_ng_path, facter_ng_version, 'lib', 'facter.rb')
-  require facter_ng_path
+  require facter_path('C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/gems')
 else
-  require 'facter'
+  require facter_path('/opt/puppetlabs/puppet/lib/ruby/gems')
 end
 
 time = Benchmark.realtime do


### PR DESCRIPTION
**Bug**: require 'facter' on non windows platforms, no longer returns facter 4. 
It returns facter 3.

